### PR TITLE
feat: allow nominating books from elections

### DIFF
--- a/angular-client/ng-bonk/angular.json
+++ b/angular-client/ng-bonk/angular.json
@@ -151,5 +151,8 @@
     "@schematics/angular:resolver": {
       "typeSeparator": "."
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/angular-client/ng-bonk/src/app/elections/dialog/nomination-finalize-dialog.component.html
+++ b/angular-client/ng-bonk/src/app/elections/dialog/nomination-finalize-dialog.component.html
@@ -1,0 +1,49 @@
+<h2 mat-dialog-title>Nominate this book</h2>
+
+<mat-dialog-content>
+  <div class="book-summary">
+    <div class="cover">
+      <app-book-cover [src]="coverUrl" [alt]="data.book.title + ' cover'"></app-book-cover>
+    </div>
+    <div class="meta">
+      <div class="title">{{ data.book.title }}</div>
+      <div class="author">{{ author }}</div>
+      @if (data.book.first_publish_year) {
+        <div class="year">First published {{ data.book.first_publish_year }}</div>
+      }
+    </div>
+  </div>
+
+  <div class="form-grid">
+    <mat-form-field appearance="outline" class="w-full">
+      <mat-label>Add to shelf (optional)</mat-label>
+      <mat-select
+        [formControl]="shelfControl"
+        [disabled]="loadingShelves">
+        <mat-option [value]="null">Do not add to a shelf</mat-option>
+        @for (shelf of shelves; track shelf.id) {
+          <mat-option [value]="shelf.id">{{ shelf.title }}</mat-option>
+        }
+      </mat-select>
+      <mat-hint>Select a shelf to keep track of the nomination.</mat-hint>
+    </mat-form-field>
+    @if (loadingShelves) {
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    }
+
+    <mat-form-field appearance="outline" class="w-full">
+      <mat-label>Pitch (optional)</mat-label>
+      <textarea
+        matInput
+        rows="4"
+        [formControl]="pitchControl"
+        placeholder="Why should this book be nominated?"></textarea>
+      <mat-hint align="end">{{ pitchControl.value.length }}/1200</mat-hint>
+    </mat-form-field>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Back</button>
+  <button mat-raised-button color="primary" (click)="confirm()">Nominate</button>
+</mat-dialog-actions>

--- a/angular-client/ng-bonk/src/app/elections/dialog/nomination-finalize-dialog.component.scss
+++ b/angular-client/ng-bonk/src/app/elections/dialog/nomination-finalize-dialog.component.scss
@@ -1,0 +1,44 @@
+.book-summary {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.book-summary .cover {
+  width: 96px;
+  height: 140px;
+  border: 1px solid #00ff41;
+}
+
+.book-summary .meta .title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.book-summary .meta .author {
+  opacity: 0.85;
+  margin-bottom: 2px;
+}
+
+.book-summary .meta .year {
+  opacity: 0.7;
+  font-size: 12px;
+}
+
+.form-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+@media (max-width: 600px) {
+  .book-summary {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .book-summary .cover {
+    align-self: center;
+  }
+}

--- a/angular-client/ng-bonk/src/app/elections/dialog/nomination-finalize-dialog.component.ts
+++ b/angular-client/ng-bonk/src/app/elections/dialog/nomination-finalize-dialog.component.ts
@@ -1,0 +1,111 @@
+import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ShelfHttpService } from '../../service/http/shelves-http.service';
+import { ShelfResponse } from '../../model/response/shelf-response.model';
+import { BookHttpService } from '../../service/http/books-http.service';
+import { OpenLibraryBookResponse } from '../../model/response/open-library-book-response.model';
+import { BookCoverComponent } from '../../common/book-cover.component';
+import { NotificationService } from '../../service/notification.service';
+
+export interface NominationFinalizeDialogData {
+  book: OpenLibraryBookResponse;
+}
+
+export interface NominationFinalizeDialogResult {
+  shelfId: string | null;
+  pitch: string;
+}
+
+@Component({
+  selector: 'app-nomination-finalize-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatProgressBarModule,
+    ReactiveFormsModule,
+    BookCoverComponent,
+  ],
+  templateUrl: './nomination-finalize-dialog.component.html',
+  styleUrls: ['./nomination-finalize-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NominationFinalizeDialogComponent implements OnInit {
+  readonly pitchControl = new FormControl<string>('', {
+    nonNullable: true,
+    validators: [Validators.maxLength(1200)],
+  });
+
+  readonly shelfControl = new FormControl<string | null>(null);
+
+  shelves: ShelfResponse[] = [];
+  loadingShelves = true;
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<
+      NominationFinalizeDialogComponent,
+      NominationFinalizeDialogResult
+    >,
+    @Inject(MAT_DIALOG_DATA) public readonly data: NominationFinalizeDialogData,
+    private readonly shelvesHttp: ShelfHttpService,
+    private readonly bookHttp: BookHttpService,
+    private readonly notify: NotificationService
+  ) {}
+
+  ngOnInit(): void {
+    this.shelvesHttp.getUserShelves().subscribe({
+      next: shelves => {
+        this.shelves = shelves
+          .filter(shelf => shelf.title !== 'My Nominations')
+          .sort((a, b) => a.title.localeCompare(b.title));
+        this.loadingShelves = false;
+      },
+      error: () => {
+        this.loadingShelves = false;
+        this.notify.error('Unable to load your shelves');
+      },
+    });
+  }
+
+  get coverUrl(): string {
+    const coverId = this.data.book.cover_i;
+    return coverId
+      ? this.bookHttp.getOpenLibraryCoverImageUrl(coverId, 'L')
+      : '';
+  }
+
+  get author(): string {
+    return this.data.book.author_name?.[0] ?? 'Unknown';
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+
+  confirm(): void {
+    if (this.pitchControl.invalid) {
+      this.pitchControl.markAsTouched();
+      return;
+    }
+
+    this.dialogRef.close({
+      shelfId: this.shelfControl.value,
+      pitch: this.pitchControl.value,
+    });
+  }
+}

--- a/angular-client/ng-bonk/src/app/elections/election-detail.component.html
+++ b/angular-client/ng-bonk/src/app/elections/election-detail.component.html
@@ -49,6 +49,13 @@
           @if (!myNomination) {
             <button
               mat-stroked-button
+              (click)="openNominateSearch()"
+              [disabled]="ballotLocked">
+              <mat-icon>library_add</mat-icon>
+              Search &amp; nominate
+            </button>
+            <button
+              mat-stroked-button
               (click)="openNominateDialog()"
               [disabled]="ballotLocked">
               <mat-icon>star</mat-icon>
@@ -111,7 +118,14 @@
         </button>
         <mat-menu #actionsMenu="matMenu">
           @if (!closed) {
-            @if (!myNomination) {
+          @if (!myNomination) {
+              <button
+                mat-menu-item
+                (click)="openNominateSearch()"
+                [disabled]="ballotLocked">
+                <mat-icon>library_add</mat-icon>
+                <span>Search &amp; nominate</span>
+              </button>
               <button
                 mat-menu-item
                 (click)="openNominateDialog()"

--- a/angular-client/ng-bonk/src/app/elections/election-detail.component.ts
+++ b/angular-client/ng-bonk/src/app/elections/election-detail.component.ts
@@ -390,6 +390,25 @@ export class ElectionDetailComponent implements OnInit, OnDestroy {
       });
   }
 
+  openNominateSearch(): void {
+    import('./sheet/election-book-search.sheet').then(m => {
+      this.bottomSheet
+        .open(m.ElectionBookSearchSheetComponent, {
+          panelClass: ['sheet-max', 'book-sheet'],
+          data: { electionId: this.electionId },
+        })
+        .afterDismissed()
+        .pipe(take(1))
+        .subscribe(changed => {
+          if (changed) {
+            this.store.dispatch(
+              ElectionsActions.loadCandidates({ electionId: this.electionId })
+            );
+          }
+        });
+    });
+  }
+
   removeMyNomination(candidateId: string): void {
     // Find bookId for candidate so we can also remove it from "My Nominations" shelf
     this.store

--- a/angular-client/ng-bonk/src/app/elections/sheet/election-book-search.sheet.html
+++ b/angular-client/ng-bonk/src/app/elections/sheet/election-book-search.sheet.html
@@ -1,0 +1,73 @@
+<div class="sheet-search-bar" role="search">
+  <div class="main-search">
+    <mat-form-field class="w-full" appearance="outline">
+      <mat-label>Search title or author</mat-label>
+      <input
+        matInput
+        [formControl]="searchControl"
+        placeholder="Find a book"
+        autocomplete="off"
+        [disabled]="submitting" />
+      <mat-icon matSuffix>search</mat-icon>
+    </mat-form-field>
+  </div>
+
+  <div class="spacer"></div>
+
+  <button mat-button (click)="cancel()" [disabled]="submitting">Cancel</button>
+</div>
+
+<div class="sheet-container" [class.submitting]="submitting">
+  <div class="results-container">
+    @if ((loading$ | async) && hasSearched) {
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    }
+
+    @if (results$ | async; as results) {
+      @if (hasSearched) {
+        @if (results.length > 0) {
+          <cdk-virtual-scroll-viewport
+            class="results-viewport"
+            [itemSize]="itemSize"
+            (scrolledIndexChange)="onScrolledIndexChange($event)">
+            <mat-card class="result-row-card" *cdkVirtualFor="let book of results">
+              <div class="cover">
+                <app-book-cover
+                  [src]="getCover(book)"
+                  [alt]="book.title + ' cover'"></app-book-cover>
+              </div>
+              <div class="meta">
+                <div class="title">{{ book.title }}</div>
+                <div class="author">{{ book.author_name?.[0] ?? '—' }}</div>
+                <div class="year">{{ book.first_publish_year ?? '—' }}</div>
+              </div>
+              <div class="actions">
+                <button
+                  mat-stroked-button
+                  color="accent"
+                  (click)="select(book)"
+                  [disabled]="submitting">
+                  <mat-icon>how_to_vote</mat-icon>
+                  Nominate
+                </button>
+              </div>
+            </mat-card>
+          </cdk-virtual-scroll-viewport>
+        } @else {
+          <div class="placeholder">No results found. Try a different search.</div>
+        }
+      } @else {
+        <div class="placeholder">
+          Search Open Library to nominate a new book without leaving this election.
+        </div>
+      }
+    }
+  </div>
+
+  @if (submitting) {
+    <div class="submitting-overlay">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+      <span>Saving nomination…</span>
+    </div>
+  }
+</div>

--- a/angular-client/ng-bonk/src/app/elections/sheet/election-book-search.sheet.scss
+++ b/angular-client/ng-bonk/src/app/elections/sheet/election-book-search.sheet.scss
@@ -1,0 +1,118 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 80vh;
+}
+
+.sheet-search-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 16px;
+}
+
+.sheet-container {
+  flex: 1;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.results-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.results-viewport {
+  flex: 1;
+  width: 100%;
+  overflow: auto;
+  min-height: 0;
+}
+
+.result-row-card {
+  display: grid;
+  grid-template-columns: 64px 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  border: 1px solid #00ff41;
+  background: rgba(0, 0, 0, 0.25);
+  margin: 0;
+}
+
+.result-row-card .cover {
+  width: 64px;
+  height: 92px;
+}
+
+.result-row-card .meta .title {
+  font-weight: 600;
+}
+
+.result-row-card .meta .author,
+.result-row-card .meta .year {
+  opacity: 0.8;
+  font-size: 12px;
+}
+
+.placeholder {
+  text-align: center;
+  opacity: 0.7;
+  padding: 24px;
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.submitting-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7);
+  color: #c8ff9c;
+  padding: 24px;
+}
+
+.sheet-container.submitting .result-row-card button {
+  pointer-events: none;
+}
+
+@media (max-width: 600px) {
+  .result-row-card {
+    grid-template-columns: 64px 1fr;
+    grid-template-rows: auto auto auto;
+  }
+
+  .result-row-card .actions {
+    grid-column: 1 / -1;
+  }
+
+  .result-row-card .actions button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+::ng-deep .mat-bottom-sheet-container {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  height: 80vh;
+  max-height: 80vh;
+  overflow: hidden;
+}
+
+.mat-mdc-form-field-subscript-wrapper {
+  display: none;
+}

--- a/angular-client/ng-bonk/src/app/elections/sheet/election-book-search.sheet.ts
+++ b/angular-client/ng-bonk/src/app/elections/sheet/election-book-search.sheet.ts
@@ -1,0 +1,239 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  Inject,
+  OnDestroy,
+  ViewChild,
+} from '@angular/core';
+import { AsyncPipe, CommonModule } from '@angular/common';
+import { MatBottomSheetRef, MAT_BOTTOM_SHEET_DATA } from '@angular/material/bottom-sheet';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { CdkVirtualScrollViewport, ScrollingModule } from '@angular/cdk/scrolling';
+import { Observable, Subject, Subscription, of } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap, takeUntil } from 'rxjs/operators';
+import { Store } from '@ngrx/store';
+import { BookCoverComponent } from '../../common/book-cover.component';
+import { OpenLibraryBookResponse } from '../../model/response/open-library-book-response.model';
+import * as LibraryActions from '../../store/action/library.actions';
+import {
+  selectOpenLibraryResults,
+  selectOpenLibraryTotal,
+  selectSearchLoading,
+} from '../../store/selector/library.selectors';
+import { BookHttpService } from '../../service/http/books-http.service';
+import { ElectionHttpService } from '../../service/http/election-http.service';
+import { NotificationService } from '../../service/notification.service';
+import { BookRequest } from '../../model/request/book-request.model';
+import { NominationFinalizeDialogComponent, NominationFinalizeDialogResult } from '../dialog/nomination-finalize-dialog.component';
+
+export interface ElectionBookSearchSheetData {
+  electionId: string;
+}
+
+@Component({
+  selector: 'app-election-book-search-sheet',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    AsyncPipe,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatProgressBarModule,
+    MatCardModule,
+    MatIconModule,
+    BookCoverComponent,
+    ScrollingModule,
+  ],
+  templateUrl: './election-book-search.sheet.html',
+  styleUrls: ['./election-book-search.sheet.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ElectionBookSearchSheetComponent implements AfterViewInit, OnDestroy {
+  readonly searchControl: FormControl<string | null> = new FormControl<string | null>(
+    ''
+  );
+  hasSearched = false;
+  submitting = false;
+
+  readonly results$: Observable<OpenLibraryBookResponse[]>;
+  readonly loading$: Observable<boolean>;
+  readonly total$: Observable<number>;
+
+  @ViewChild(CdkVirtualScrollViewport) viewport?: CdkVirtualScrollViewport;
+
+  private readonly destroy$ = new Subject<void>();
+  private searchSub?: Subscription;
+  private pageIndex = 0;
+  private readonly pageSize = 10;
+  private currentCount = 0;
+  private totalCount = 0;
+  private isLoading = false;
+  readonly itemSize = 110;
+  private readonly preloadThreshold = 3;
+
+  constructor(
+    private readonly sheetRef: MatBottomSheetRef<ElectionBookSearchSheetComponent>,
+    @Inject(MAT_BOTTOM_SHEET_DATA) private readonly data: ElectionBookSearchSheetData,
+    private readonly dialog: MatDialog,
+    private readonly store: Store,
+    private readonly bookHttp: BookHttpService,
+    private readonly electionHttp: ElectionHttpService,
+    private readonly notify: NotificationService
+  ) {
+    this.results$ = this.store.select(selectOpenLibraryResults);
+    this.loading$ = this.store.select(selectSearchLoading);
+    this.total$ = this.store.select(selectOpenLibraryTotal);
+  }
+
+  ngAfterViewInit(): void {
+    this.results$.pipe(takeUntil(this.destroy$)).subscribe(results => {
+      this.currentCount = results.length;
+      this.maybePrefetchMore();
+    });
+
+    this.total$.pipe(takeUntil(this.destroy$)).subscribe(total => {
+      this.totalCount = total ?? 0;
+    });
+
+    this.loading$.pipe(takeUntil(this.destroy$)).subscribe(loading => {
+      this.isLoading = loading;
+    });
+
+    this.searchSub = this.searchControl.valueChanges
+      .pipe(takeUntil(this.destroy$), debounceTime(300), distinctUntilChanged())
+      .subscribe(() => {
+        this.pageIndex = 0;
+        this.loadData();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.searchSub?.unsubscribe();
+  }
+
+  loadData(): void {
+    const query = (this.searchControl.value ?? '').trim();
+    this.hasSearched = true;
+    this.store.dispatch(
+      LibraryActions.searchOpenLibrary({
+        query,
+        pageIndex: this.pageIndex,
+        pageSize: this.pageSize,
+      })
+    );
+  }
+
+  getCover(book: OpenLibraryBookResponse): string {
+    return book.cover_i
+      ? this.bookHttp.getOpenLibraryCoverImageUrl(book.cover_i, 'M')
+      : '';
+  }
+
+  cancel(): void {
+    this.sheetRef.dismiss();
+  }
+
+  select(book: OpenLibraryBookResponse): void {
+    if (this.submitting) {
+      return;
+    }
+
+    this.dialog
+      .open(NominationFinalizeDialogComponent, {
+        width: '520px',
+        data: { book },
+        disableClose: true,
+      })
+      .afterClosed()
+      .pipe(
+        takeUntil(this.destroy$),
+        switchMap((result?: NominationFinalizeDialogResult) => {
+          if (!result) {
+            return of(null);
+          }
+          const payload: BookRequest = {
+            title: book.title,
+            author: book.author_name?.[0] || 'Unknown',
+            imageURL: book.cover_i
+              ? this.bookHttp.getOpenLibraryCoverImageUrl(book.cover_i, 'L')
+              : '',
+            blurb: result.pitch?.trim() ?? '',
+            openLibraryId: book.key,
+            shelfIds: result.shelfId ? [result.shelfId] : undefined,
+          };
+          this.submitting = true;
+          return this.bookHttp.createBook(payload).pipe(
+            switchMap(created =>
+              this.electionHttp
+                .nominateCandidate(this.data.electionId, created.id)
+                .pipe(switchMap(() => of(created)))
+            )
+          );
+        })
+      )
+      .subscribe({
+        next: created => {
+          if (!created) {
+            return;
+          }
+          this.notify.success('Book nominated to election');
+          this.sheetRef.dismiss(true);
+        },
+        error: err => {
+          this.submitting = false;
+          const message = err?.error?.message ?? 'Failed to nominate book';
+          this.notify.error(message);
+        },
+        complete: () => {
+          this.submitting = false;
+        },
+      });
+  }
+
+  onScrolledIndexChange(index: number): void {
+    const visible = this.viewport
+      ? Math.ceil(this.viewport.getViewportSize() / this.itemSize)
+      : 10;
+    const nearEnd = index + visible + this.preloadThreshold >= this.currentCount;
+    if (
+      this.hasSearched &&
+      !this.isLoading &&
+      this.currentCount < this.totalCount &&
+      nearEnd
+    ) {
+      this.pageIndex++;
+      this.loadData();
+    }
+  }
+
+  private maybePrefetchMore(): void {
+    if (
+      !this.hasSearched ||
+      this.isLoading ||
+      this.currentCount >= this.totalCount
+    ) {
+      return;
+    }
+    const visible = this.viewport
+      ? Math.ceil(this.viewport.getViewportSize() / this.itemSize)
+      : 10;
+    if (this.currentCount < Math.max(visible + this.preloadThreshold, this.pageSize)) {
+      this.pageIndex++;
+      this.loadData();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an election-specific book search sheet that lets users nominate new titles with optional shelf placement and pitch
- introduce a nomination finalize dialog and surface the new search action in the election detail toolbar and menu
- disable Angular CLI analytics to avoid future prompts in the workspace

## Testing
- npm run build
- npm test -- --watch=false --progress=false *(fails: Chrome binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df25e62e8c83228e747a8b71c791b2