### PR TITLE
Fix mobile scroll behavior for elections and shelves

### DIFF
--- a/angular-client/ng-bonk/src/app/elections/elections.component.scss
+++ b/angular-client/ng-bonk/src/app/elections/elections.component.scss
@@ -1,3 +1,11 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  height: 100%;
+  min-height: 0;
+}
+
 .spacer {
   flex: 1;
 }
@@ -20,16 +28,26 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .list-pane {
   max-width: 720px;
-  overflow: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .detail-pane {
   display: none;
-  overflow: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   border: 1px solid #00ff41;
 }
 
@@ -103,10 +121,14 @@
   }
   .list-pane {
     flex: 0 0 520px;
+    height: 100%;
+    min-height: 0;
   }
   .detail-pane {
     display: block;
     flex: 1 1 auto;
+    height: 100%;
+    min-height: 0;
   }
 }
 
@@ -116,5 +138,7 @@
   }
   .mobile-shown {
     display: block;
+    height: 100%;
+    min-height: 0;
   }
 }

--- a/angular-client/ng-bonk/src/styles.scss
+++ b/angular-client/ng-bonk/src/styles.scss
@@ -20,7 +20,9 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .route-container {
@@ -31,7 +33,9 @@ body {
   flex: 1;
   display: flex;
   flex-flow: column;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .scrollable-container {
@@ -42,7 +46,9 @@ body {
   flex: 1;
   display: flex;
   flex-flow: column;
-  overflow: scroll;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 // No scroll so far...


### PR DESCRIPTION
## Summary
- allow the app and route containers to scroll vertically on touch devices so long views remain usable on mobile
- update the elections layout so its panes flex correctly and expose vertical scrolling when space is constrained

## Testing
- npm run build
- CI=true npm test -- --watch=false *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a3a84248832288564e065848240f