### PR TITLE
Add system status component to home

### DIFF
--- a/angular-client/akira-ng/src/app/feature/home/home.html
+++ b/angular-client/akira-ng/src/app/feature/home/home.html
@@ -120,4 +120,7 @@
       </div>
     </div>
   </div>
+
+  <!-- SYSTEM STATUS -->
+  <app-system-status />
 </div>

--- a/angular-client/akira-ng/src/app/feature/home/home.ts
+++ b/angular-client/akira-ng/src/app/feature/home/home.ts
@@ -1,9 +1,10 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { SystemStatusComponent } from './system-status.component';
 
 @Component({
   selector: 'app-home',
-  imports: [RouterLink],
+  imports: [RouterLink, SystemStatusComponent],
   templateUrl: './home.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './home.css',

--- a/angular-client/akira-ng/src/app/feature/home/system-status.component.html
+++ b/angular-client/akira-ng/src/app/feature/home/system-status.component.html
@@ -1,0 +1,36 @@
+<div class="px-2 max-sm:px-4">
+  <div class="rounded-lg border border-rule bg-bg-subtle p-5">
+    <div class="flex items-center justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-[0.15em] text-fg-subtle">System status</h2>
+      <button type="button" (click)="refresh()" [disabled]="checking()"
+              class="inline-flex items-center gap-1.5 rounded-md border border-rule px-2 py-1 text-xs font-medium text-fg-muted transition hover:bg-bg hover:text-fg disabled:opacity-60">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round" class="size-3.5"
+             [class.animate-spin]="checking()">
+          <path d="M21 12a9 9 0 1 1-2.64-6.36M21 3v6h-6" />
+        </svg>
+        Refresh
+      </button>
+    </div>
+
+    <ul class="mt-4 grid gap-2">
+      @for (s of services(); track s.key) {
+        <li class="flex items-center justify-between gap-3 rounded-md border border-rule bg-bg px-3 py-2.5">
+          <span class="flex items-center gap-2.5">
+            <span class="size-2.5 shrink-0 rounded-full" [class]="dotClass(s.status)"
+                  [class.animate-pulse]="s.status === 'checking'" aria-hidden="true"></span>
+            <span class="text-sm font-medium text-fg">{{ s.label }}</span>
+          </span>
+          <span class="text-xs font-medium" [class]="textClass(s.status)">{{ statusLabel(s.status) }}</span>
+        </li>
+      }
+    </ul>
+
+    <p class="mt-3 text-xs text-fg-subtle">
+      @if (lastChecked(); as t) {
+        Last checked {{ t | date: 'shortTime' }} ·
+      }
+      Re-checks every 30s.
+    </p>
+  </div>
+</div>

--- a/angular-client/akira-ng/src/app/feature/home/system-status.component.ts
+++ b/angular-client/akira-ng/src/app/feature/home/system-status.component.ts
@@ -1,0 +1,102 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  OnInit,
+  computed,
+  signal,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+
+type Status = 'checking' | 'up' | 'down';
+
+interface ServiceCheck {
+  readonly key: string;
+  readonly label: string;
+  /** Same-origin, permit-all GET that returns 200 when the service is up. */
+  readonly url: string;
+  readonly status: Status;
+}
+
+/**
+ * Live availability of the moving parts behind Akira. Each row pings a
+ * same-origin, public endpoint with native `fetch` (so the global HTTP error
+ * interceptor doesn't toast on the failures we expect) and shows a dot:
+ * green = up, red = unavailable, amber = checking. Re-checks every 30s.
+ *
+ * Endpoints are reachable without auth: the backends' list endpoints are
+ * permit-all, and the remote entry is a static file — a 200 means "alive".
+ */
+@Component({
+  selector: 'app-system-status',
+  imports: [DatePipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './system-status.component.html',
+})
+export class SystemStatusComponent implements OnInit, OnDestroy {
+  protected readonly services = signal<readonly ServiceCheck[]>([
+    { key: 'akira-api', label: 'Akira backend', url: '/bff/api/tag', status: 'checking' },
+    { key: 'ooze-api', label: 'Oozengine backend', url: '/bff/ooz/spell', status: 'checking' },
+    { key: 'ooze-mfe', label: 'Oozengine frontend', url: '/remotes/ooze/remoteEntry.json', status: 'checking' },
+  ]);
+  protected readonly lastChecked = signal<Date | null>(null);
+  protected readonly checking = computed(() => this.services().some(s => s.status === 'checking'));
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  ngOnInit(): void {
+    void this.checkAll();
+    this.timer = setInterval(() => void this.checkAll(), 30_000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.timer) clearInterval(this.timer);
+  }
+
+  protected refresh(): void {
+    this.services.update(list => list.map(s => ({ ...s, status: 'checking' as Status })));
+    void this.checkAll();
+  }
+
+  protected statusLabel(status: Status): string {
+    return status === 'up' ? 'Operational' : status === 'down' ? 'Unavailable' : 'Checking…';
+  }
+
+  protected dotClass(status: Status): string {
+    return status === 'up' ? 'bg-success' : status === 'down' ? 'bg-danger' : 'bg-fg-subtle';
+  }
+
+  protected textClass(status: Status): string {
+    return status === 'up' ? 'text-success' : status === 'down' ? 'text-danger' : 'text-fg-subtle';
+  }
+
+  private async checkAll(): Promise<void> {
+    await Promise.all(this.services().map(s => this.probe(s.key, s.url)));
+    this.lastChecked.set(new Date());
+  }
+
+  private async probe(key: string, url: string): Promise<void> {
+    const ok = await this.ping(url);
+    this.services.update(list =>
+      list.map(s => (s.key === key ? { ...s, status: ok ? 'up' : 'down' } : s)),
+    );
+  }
+
+  private async ping(url: string): Promise<boolean> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        cache: 'no-store',
+        credentials: 'same-origin',
+        signal: controller.signal,
+      });
+      return res.ok;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}


### PR DESCRIPTION
Introduce a new SystemStatusComponent (system-status.component.ts/.html) that displays live availability of backend/frontend services. The component pings three same-origin endpoints (/bff/api/tag, /bff/ooz/spell, /remotes/ooze/remoteEntry.json) using native fetch with a 5s timeout, shows per-service status (checking/up/down), provides a Refresh button, and re-checks every 30s. It uses Angular signals/computed and DatePipe with OnPush change detection. Also register the component in the Home component imports and insert <app-system-status /> into home.html.